### PR TITLE
README.md: bring back the title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# SwiftLint Action
+
 Run [SwiftLint](https://github.com/realm/SwiftLint) from your GitHub Actions
 with ease and annotations.
 


### PR DESCRIPTION
The `README.md` looks pretty weird without it.